### PR TITLE
chore(release): 0.5.0b0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,58 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0b0] - 2026-06-24
+
+### Added
+
+- **Flask adapter** (`[flask]` optional extras group) — adds a `FlaskRenderer`
+  (Jinja2-backed; share the app's `jinja_env` for consistent filters, globals,
+  and extensions) and a synchronous component endpoint exposed as a Flask
+  blueprint (`POST /components/<name>` via `register_component_routes(app)` or
+  `create_component_blueprint()`). Parses JSON and HTMX form-encoded bodies and
+  returns JSON `404`/`400`/`500` errors. The `[flask]` extra pulls only
+  `flask>=3.0` — no FastAPI/Django/JinjaX. See `examples/flask_example.py`.
+- **Optimistic UI patching in the client** — `component-client.js` now applies
+  an optimistic patch synchronously before the request completes, reading
+  `data-optimistic` JSON / `data-optimistic-toggle` from the trigger element and
+  rolling back when the server response arrives. Ships an accompanying
+  `component-framework.css` with `[data-loading]` / `[data-optimistic]` hooks
+  (reduced-motion aware) and updated `component-client.d.ts` typings.
+- **Sharing an existing JinjaX catalog** — documented and clarified that
+  `JinjaxRenderer` should be constructed with the application's existing
+  `Catalog` so component templates inherit host globals and filters, rather than
+  a fresh, empty catalog.
+
+### Changed
+
+- `[all]` and `[dev]` extras groups now include the `flask` extra.
+
+## [0.4.1b0] - 2026-06-23
+
+### Fixed
+
+- FastAPI and Litestar adapters now accept form-encoded (HTMX default)
+  `POST` bodies in addition to JSON.
+- CI: `ty`'s `invalid-method-override` diagnostic is treated as a warning to
+  accommodate Django's CBV/consumer signature narrowing.
+
+## [0.4.0b0] - 2026-03-01
+
+### Added
+
+- **Litestar adapter** (`[litestar]` optional extras group) — HTTP, WebSocket,
+  and SSE support.
+- **Async event handlers** — `async_dispatch()` / `async_handle_event()` for
+  adapters running in an async context.
+- **SSE streaming** — `StreamingComponent` with async-generator handlers for
+  progressive rendering.
+- **State size guard** — configurable warning at 64 KB and a hard limit at
+  512 KB on serialised component state.
+
+### Fixed
+
+- JS double-serialisation fix in `component-client.js`.
+
 ## [0.3.0b0] - 2026-02-23
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Framework-agnostic server components with LiveView-style interactivity inspired 
 
 ## Development Status
 
-**Current Version:** 0.4.0-beta
+**Current Version:** 0.5.0-beta
 **API Documentation:** [fsecada01.github.io/component-framework](https://fsecada01.github.io/component-framework/)
 
 The framework has a complete, tested feature set covering the full Beta roadmap. APIs are solidifying — the core lifecycle, permissions, composition, and testing utilities are stable. We welcome feedback before the 1.0 release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "component-framework"
-version = "0.4.1b0"
+version = "0.5.0b0"
 description = "Framework-agnostic server components with LiveView-style interactivity"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Release 0.5.0b0

Minor beta release bundling the three features merged since `v0.4.1b0`.

### Highlights
- **Flask adapter** (`[flask]` extra) — `FlaskRenderer` + sync component blueprint (`POST /components/<name>`); JSON + HTMX form-encoded bodies; pulls only `flask>=3.0`. (#5 / #19)
- **Optimistic UI** — client-side patch applied before the request resolves, with rollback; new `component-framework.css` hooks. (#16 / #17)
- **JinjaX catalog sharing** — guidance + docs for constructing `JinjaxRenderer` with the host app's existing `Catalog`. (#13 / #18)

### Changes in this PR
- Bump `pyproject.toml` version `0.4.1b0` → `0.5.0b0` (new adapter ⇒ minor bump).
- `CHANGELOG.md`: add `[0.5.0b0]`; backfill the previously-missing `[0.4.1b0]` and `[0.4.0b0]` sections.
- `README.md`: Current Version → `0.5.0-beta`.

### Verification
- `just build` → `component_framework-0.5.0b0` sdist + wheel build cleanly.
- Full suite: **420 passed**; `prek run --all-files` clean (ruff, ruff-format, ty).

### After merge
Tag `v0.5.0b0` (auto-deploys versioned API docs via `docs.yml`) and publish a GitHub Release. No PyPI push (no publish workflow configured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
