### PR TITLE
docs: multi-step wizard recipe + example for FastAPI adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Generated from docstrings by pdoc and deployed to GitHub Pages on every push to 
 | [Django Implementation](docs/DJANGO_IMPLEMENTATION.md) | Django adapter setup and patterns |
 | [Class-Based Views](docs/CBV_GUIDE.md) | CBV auth/permission patterns |
 | [E-Commerce Example](docs/examples/ecommerce.md) | Real-time cart + product demo |
+| [Multi-Step Wizard](docs/examples/wizard.md) | FastAPI wizard recipe (unsigned state — pending Epic A1) |
 
 ### AI / LLM Context
 
@@ -404,6 +405,7 @@ component-framework/
 │
 ├── examples/
 │   ├── fastapi_example.py           # FastAPI demo
+│   ├── fastapi_wizard_example.py    # Multi-step wizard demo
 │   ├── litestar_example.py          # Litestar demo
 │   └── django_example/              # Complete Django app
 │
@@ -437,7 +439,9 @@ component-framework/
 │   ├── docs_settings.py             # Minimal Django settings for pdoc
 │   ├── pdoc_templates/              # Custom pdoc templates (terminal brutalism)
 │   ├── update_gh_pages.py           # CI helper: versions.json + root index
-│   └── examples/ecommerce.md        # Real-time e-commerce walkthrough
+│   └── examples/
+│       ├── ecommerce.md             # Real-time e-commerce walkthrough
+│       └── wizard.md                # Multi-step wizard recipe (FastAPI)
 │
 ├── .github/workflows/
 │   ├── ci.yml                       # Tests, lint, type check (Python 3.11–3.14)

--- a/claudedocs/research_liveview_market_2026-06-24.md
+++ b/claudedocs/research_liveview_market_2026-06-24.md
@@ -208,7 +208,7 @@ Below: the production-grade checklist synthesized from Phoenix LiveView (gold st
 
 ## 5. Competitor Weaknesses to Exploit (Confidence: Medium-High)
 
-- **Reflex** ($5M seed): compiles to a Next.js SPA with a **mandatory live WS to Python** (scaling/latency), steep learning curve, **standalone (can't drop into an existing app)**, dashboard-leaning, Pydantic-v1 internals → **Python 3.14 build failures** (#5964). 
+- **Reflex** ($5M seed): compiles to a Next.js SPA with a **mandatory live WS to Python** (scaling/latency), steep learning curve, **standalone (can't drop into an existing app)**, dashboard-leaning, Pydantic-v1 internals → **Python 3.14 build failures** (#5964).
 - **Django Unicorn / Tetra / Reactor / Sockpuppet** — **Django-only**; several require Channels/Redis; small bus factors; "unknown" production maturity.
 - **FastUI** — Pydantic-backed but **officially dormant** (#368) — a *funded project that stalled*, leaving the segment open.
 - **ReactPy** — every interaction is a server round-trip + VDOM diff → less responsive than client React.

--- a/docs/examples/wizard.md
+++ b/docs/examples/wizard.md
@@ -1,0 +1,233 @@
+# Multi-Step Wizard (FastAPI)
+
+> Runnable example: [`examples/fastapi_wizard_example.py`](../../examples/fastapi_wizard_example.py)
+
+A guided, multi-step form — collect a few fields, validate them, move on,
+let the user go back and see what they already entered, then do something
+with the accumulated data on the final step. This is the pattern behind
+things like onboarding flows, checkout, and (the concrete driver for this
+recipe) a resume-tailoring wizard.
+
+---
+
+## Before you build one: read this
+
+**A production-grade wizard needs signed state.** Every component-framework
+request round-trips the component's state to the browser and back
+(`dispatch(state=...)` → `result["state"]`). Today that round-trip is
+**unsigned** — nothing stops a client from editing the serialized state blob
+before posting it back. For a single counter that's harmless. For a wizard
+that accumulates several steps of validated data, a tampered state blob
+could let a client skip validation on an earlier step, or submit the final
+step with fabricated `collected` data for an earlier one.
+
+Signed state is tracked as **Epic A / A1** and does not exist yet as of this
+writing (no `CorruptStateError`, no `sign_state`, nothing in
+`core/component.py`'s `StateSerializer`). **A4** (CSRF coverage for the
+FastAPI adapter) is also outstanding — the FastAPI adapter has no CSRF
+handling at all right now, unlike the Django adapter.
+
+This recipe and its example are written against the **current, unsigned**
+state model, so you can build a wizard today. Two things to do once A1/A4
+land:
+
+- Swap the plain `state=...` round-trip for whatever signed-state API A1
+  introduces — no change to the component's own logic should be needed.
+- Add CSRF protection at the app level for the wizard's POST route (a
+  double-submit-cookie middleware, or whatever your app already uses for
+  other POST endpoints) until A4 ships a first-class mechanism.
+
+Until then: **don't put anything in a wizard's accumulated state that you
+wouldn't be comfortable with a malicious client tampering with.** If the
+final step's handler is about to write to your database, re-validate the
+data you actually need server-side rather than trusting `collected`
+blindly (e.g. re-check foreign keys exist, re-check ownership).
+
+---
+
+## Why not `CompositeComponent` per step?
+
+If you've read the framework's docs/README, you may expect a
+`CompositeComponent` host with one child `FormComponent` per step, wired
+via slots. **That primitive doesn't exist in the codebase today** — only
+`Component.fill_slot()` / `render_slots()` and the `compose()` helper in
+`core/composition.py`, which compose components for **rendering** (a parent
+template with pre-rendered child HTML dropped into named slots).
+
+That's a fundamentally different problem than a wizard's needs. Each POST to
+`/components/{name}` dispatches **exactly one** registered component — hydrate
+→ handle event → render → dehydrate — for that one component only. There's
+no framework machinery that would hydrate a parent *and* an independently
+addressable per-step child component in the same request and keep both
+in sync across steps. Modeling a wizard as a parent + slotted children
+would mean inventing your own protocol for shuttling child state through
+the parent's state anyway — at which point you've just built the pattern
+below with extra ceremony.
+
+**The pattern that actually works:** one component owns the whole wizard.
+It tracks which step is active and the data collected so far, and swaps
+which schema it validates against based on the active step.
+
+---
+
+## The Component
+
+```python
+# resume_wizard.py
+from typing import ClassVar
+
+from pydantic import BaseModel, EmailStr, Field
+
+from component_framework.core import FormComponent, registry
+
+
+class ContactStepSchema(BaseModel):
+    name: str = Field(min_length=2, max_length=100)
+    email: EmailStr
+
+
+class TargetRoleStepSchema(BaseModel):
+    job_title: str = Field(min_length=2, max_length=100)
+    company: str = Field(min_length=2, max_length=100)
+
+
+# The final "review" step has no fields to validate, so no schema.
+STEPS: list[dict] = [
+    {"key": "contact", "title": "Contact Info", "schema": ContactStepSchema},
+    {"key": "target_role", "title": "Target Role", "schema": TargetRoleStepSchema},
+    {"key": "review", "title": "Review & Generate", "schema": None},
+]
+
+
+@registry.register("resume_wizard")
+class ResumeWizard(FormComponent):
+    steps: ClassVar[list[dict]] = STEPS
+    template_name = "Wizard"
+
+    def mount(self):
+        super().mount()
+        self.state.setdefault("step_index", 0)
+        self.state.setdefault("collected", {})
+        self._load_current_step_form_data()
+
+    def _current_step(self) -> dict:
+        return self.steps[self.state["step_index"]]
+
+    def _load_current_step_form_data(self):
+        """Pre-fill from previously-entered data when navigating back."""
+        step = self._current_step()
+        self.state["form_data"] = self.state["collected"].get(step["key"], {})
+        self.field_errors = {}
+
+    @property
+    def schema(self):
+        """FormComponent.validate() reads this — point it at the active step."""
+        return self._current_step().get("schema")
+
+    def on_advance(self, form_data: dict):
+        step = self._current_step()
+        self.state["form_data"] = form_data
+
+        if step.get("schema") and not self.validate(form_data):
+            return  # field_errors populated by validate(); stay on this step
+
+        if step.get("schema"):
+            self.state["collected"][step["key"]] = self.validated_data
+
+        if self.state["step_index"] < len(self.steps) - 1:
+            self.state["step_index"] += 1
+            self._load_current_step_form_data()
+
+    def on_back(self):
+        if self.state["step_index"] > 0:
+            self.state["step_index"] -= 1
+            self._load_current_step_form_data()
+
+    def on_submit(self):
+        """
+        Final step. This is where an app persists the wizard's result —
+        the framework does not do this for you. For example:
+
+            ResumeDraft.objects.create(**self.state["collected"]["contact"], ...)
+
+        Re-validate anything security-sensitive here rather than trusting
+        ``collected`` outright — see the state-signing caveat above.
+        """
+        self.state["completed"] = True
+
+    def get_context(self) -> dict:
+        context = super().get_context()
+        context.update({
+            "step_index": self.state["step_index"],
+            "step_key": self._current_step()["key"],
+            "step_title": self._current_step()["title"],
+            "step_titles": [s["title"] for s in self.steps],
+            "is_last_step": self.state["step_index"] == len(self.steps) - 1,
+            "collected": self.state.get("collected", {}),
+            "completed": self.state.get("completed", False),
+        })
+        return context
+```
+
+Three things make this work:
+
+1. **`schema` becomes a property, not a fixed `ClassVar`.** `FormComponent.validate()`
+   reads `self.schema` — overriding it as a property lets each step supply its
+   own Pydantic model without needing per-step component subclasses.
+2. **`on_advance` validates and *then* decides whether to move.** A failed
+   validation leaves `step_index` untouched and populates `field_errors`
+   exactly like a single-page `FormComponent` would — the difference is just
+   that we route through `validate()` manually instead of going through
+   `handle_event`'s built-in `"submit"` branch.
+3. **The last step reuses `"submit"`, not `"advance"`.** Since the review
+   step has `schema: None`, `FormComponent.handle_event`'s existing
+   `"submit"` handling (validate → call `on_submit`) works unchanged — no
+   special-casing needed for the terminal step.
+
+## The Template
+
+The template switches which fields it renders based on `step_key`, and
+posts each field's live value explicitly via `hx-vals='js:{...}'` (rather
+than relying on `hx-include`, which doesn't nest into the component
+endpoint's `payload.form_data` shape). See
+[`templates/components/Wizard.jinja`](../../templates/components/Wizard.jinja)
+for the full template — the "Next" button on the contact step looks like:
+
+```html
+<button
+  type="button"
+  hx-post="/components/resume_wizard"
+  hx-vals='js:{"event": "advance", "payload": {"form_data": {"name": document.getElementById("wiz-name").value, "email": document.getElementById("wiz-email").value}}, "state": {{ state | tojson }}, "params": {"component_id": "{{ component_id }}"}}'
+  hx-target="#{{ component_id }}"
+  hx-swap="outerHTML"
+>Next</button>
+```
+
+"Back" posts an `"back"` event with an empty payload; the final step's
+"Generate" button posts `"submit"`.
+
+## What happens to state when you navigate
+
+- **In-flight wizard data lives entirely in the client-held state blob**
+  (unsigned today, signed once A1 lands) — not on the server, not in a
+  database. If the
+  user closes the tab mid-wizard, everything they entered is gone unless
+  your app persists it somewhere (e.g. autosaving `collected` after each
+  step).
+- **Going back doesn't discard anything.** `on_back` only moves
+  `step_index`; `collected` is untouched, so `_load_current_step_form_data`
+  re-populates the earlier step's fields from what's already stored.
+- **The framework never writes anything server-side.** `on_submit` is where
+  *your app* takes `self.state["collected"]` and does something durable
+  with it (save a model, kick off a background job, etc.) — component-framework's
+  job ends at handing you validated, accumulated data.
+
+## Running it
+
+```bash
+uv run python examples/fastapi_wizard_example.py
+```
+
+Open `http://localhost:8000` — fill in contact info and target role (try an
+invalid email to see per-field validation), navigate back and confirm your
+answers are still there, then generate on the review step.

--- a/examples/fastapi_wizard_example.py
+++ b/examples/fastapi_wizard_example.py
@@ -1,0 +1,216 @@
+"""FastAPI example: a multi-step wizard built from a single stateful component.
+
+Scenario: a 3-step "resume tailoring" wizard (contact info -> target role ->
+review/generate) — the reference pattern for Resume-Generator's wizard flow.
+
+NOTE ON STATE SECURITY: this example round-trips wizard state to the client
+unsigned, as component-framework does not yet ship signed state (tracked as
+Epic A / A1). Do not use this pattern for wizards that collect sensitive data
+until A1 lands — see docs/examples/wizard.md for details.
+"""
+
+import sys
+from pathlib import Path
+from typing import ClassVar
+
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+from jinjax import Catalog
+from pydantic import BaseModel, EmailStr, Field
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from component_framework.adapters.fastapi import create_component_routes
+from component_framework.adapters.jinjax_renderer import JinjaxRenderer
+from component_framework.core import Component, FormComponent, registry
+
+# Initialize FastAPI
+app = FastAPI(title="Component Framework - Wizard Demo")
+
+# Setup Jinjax
+templates_dir = Path(__file__).parent.parent / "templates" / "components"
+catalog = Catalog()
+catalog.add_folder(templates_dir)
+catalog.jinja_env.autoescape = True
+
+# Configure renderer globally
+renderer = JinjaxRenderer(catalog)
+Component.renderer = renderer
+
+
+# ---------- Per-step schemas ----------
+
+
+class ContactStepSchema(BaseModel):
+    """Step 1: who the resume is for."""
+
+    name: str = Field(min_length=2, max_length=100)
+    email: EmailStr
+
+
+class TargetRoleStepSchema(BaseModel):
+    """Step 2: what role the resume should be tailored for."""
+
+    job_title: str = Field(min_length=2, max_length=100)
+    company: str = Field(min_length=2, max_length=100)
+
+
+# The final "review" step has no input fields to validate — it just confirms
+# the accumulated data and triggers generation, so it has no schema.
+
+STEPS: list[dict] = [
+    {"key": "contact", "title": "Contact Info", "schema": ContactStepSchema},
+    {"key": "target_role", "title": "Target Role", "schema": TargetRoleStepSchema},
+    {"key": "review", "title": "Review & Generate", "schema": None},
+]
+
+
+# ---------- Component ----------
+
+
+@registry.register("resume_wizard")
+class ResumeWizard(FormComponent):
+    """
+    Multi-step wizard implemented as a single component that owns
+    ``step_index`` and swaps which step's fields/schema are active.
+
+    There is no ``CompositeComponent``-per-step primitive in the framework
+    today — each POST to /components/{name} dispatches exactly one
+    registered component, so a wizard's cross-step state (which step is
+    active, and what was entered on earlier steps) has to live on one
+    component rather than being split across independently-dispatched
+    child components. See docs/examples/wizard.md for the full writeup.
+    """
+
+    steps: ClassVar[list[dict]] = STEPS
+    template_name = "Wizard"
+
+    def mount(self):
+        super().mount()
+        self.state.setdefault("step_index", 0)
+        self.state.setdefault("collected", {})
+        self._load_current_step_form_data()
+
+    # ---------- Step helpers ----------
+
+    def _current_step(self) -> dict:
+        return self.steps[self.state["step_index"]]
+
+    def _load_current_step_form_data(self):
+        """Pre-fill form_data from previously-entered data for this step."""
+        step = self._current_step()
+        self.state["form_data"] = self.state["collected"].get(step["key"], {})
+        self.field_errors = {}
+
+    @property
+    def schema(self):
+        """Validate against the *active* step's schema, not a fixed one."""
+        return self._current_step().get("schema")
+
+    # ---------- Navigation ----------
+
+    def on_advance(self, form_data: dict):
+        """Validate the current step and move to the next one."""
+        step = self._current_step()
+        self.state["form_data"] = form_data
+
+        if step.get("schema") and not self.validate(form_data):
+            # field_errors is populated by validate(); stay on this step.
+            return
+
+        if step.get("schema"):
+            self.state["collected"][step["key"]] = self.validated_data
+
+        if self.state["step_index"] < len(self.steps) - 1:
+            self.state["step_index"] += 1
+            self._load_current_step_form_data()
+
+    def on_back(self):
+        """Move to the previous step without validating the current one."""
+        if self.state["step_index"] > 0:
+            self.state["step_index"] -= 1
+            self._load_current_step_form_data()
+
+    def on_submit(self):
+        """
+        Final step: hand the accumulated wizard data to the application.
+
+        The framework does not persist this anywhere — that's an app-level
+        concern. A real app would write ``self.state["collected"]`` to its
+        own models here (e.g. create a ResumeDraft row).
+        """
+        self.state["completed"] = True
+
+    # ---------- Context ----------
+
+    def get_context(self) -> dict:
+        context = super().get_context()
+        context.update(
+            {
+                "step_index": self.state["step_index"],
+                "step_key": self._current_step()["key"],
+                "step_title": self._current_step()["title"],
+                "step_titles": [s["title"] for s in self.steps],
+                "is_last_step": self.state["step_index"] == len(self.steps) - 1,
+                "collected": self.state.get("collected", {}),
+                "completed": self.state.get("completed", False),
+            }
+        )
+        return context
+
+
+# Add component routes
+create_component_routes(app)
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index():
+    """Serve demo page with initial wizard render."""
+    wizard = ResumeWizard()
+    result = wizard.dispatch()
+
+    return f"""
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <title>Wizard Component Demo</title>
+        <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+        <style>
+            body {{
+                font-family: system-ui, -apple-system, sans-serif;
+                max-width: 600px;
+                margin: 50px auto;
+                padding: 20px;
+                color: #333;
+            }}
+            h1 {{ text-align: center; }}
+            .info {{
+                background: #e3f2fd;
+                padding: 15px;
+                border-radius: 8px;
+                margin: 20px 0;
+            }}
+        </style>
+    </head>
+    <body>
+        <h1>Resume Wizard Demo</h1>
+
+        <div class="info">
+            <p>A 3-step wizard built from <strong>one stateful component</strong>
+            that tracks <code>step_index</code> and per-step validated data.
+            Unsigned state round-trip — see docs/examples/wizard.md.</p>
+        </div>
+
+        {result["html"]}
+    </body>
+    </html>
+    """
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    print("Starting Wizard Component Demo")
+    print("Open http://localhost:8000")
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/templates/components/Wizard.jinja
+++ b/templates/components/Wizard.jinja
@@ -1,0 +1,187 @@
+{#def state, errors, component_id, form_data, field_errors, is_valid, submitted, step_index, step_key, step_title, step_titles, is_last_step, collected, completed #}
+<div id="{{ component_id }}" class="wizard">
+
+  {% if completed %}
+    <div class="wizard-done">
+      <h2>Done!</h2>
+      <p>Collected data:</p>
+      <pre>{{ collected | tojson(indent=2) }}</pre>
+    </div>
+  {% else %}
+
+    {# ---------- Progress indicator ---------- #}
+    <ol class="wizard-steps">
+      {% for title in step_titles %}
+        <li class="{% if loop.index0 == step_index %}active{% elif loop.index0 < step_index %}done{% endif %}">
+          {{ title }}
+        </li>
+      {% endfor %}
+    </ol>
+
+    <h2>{{ step_title }}</h2>
+
+    <form>
+
+      {# ---------- Step 1: Contact Info ---------- #}
+      {% if step_key == "contact" %}
+        <div class="field">
+          <label for="wiz-name">Name</label>
+          <input type="text" id="wiz-name" name="name" value="{{ form_data.get('name', '') }}" />
+          {% if field_errors.get("name") %}
+            <span class="error">{{ field_errors["name"][0] }}</span>
+          {% endif %}
+        </div>
+        <div class="field">
+          <label for="wiz-email">Email</label>
+          <input type="email" id="wiz-email" name="email" value="{{ form_data.get('email', '') }}" />
+          {% if field_errors.get("email") %}
+            <span class="error">{{ field_errors["email"][0] }}</span>
+          {% endif %}
+        </div>
+      {% endif %}
+
+      {# ---------- Step 2: Target Role ---------- #}
+      {% if step_key == "target_role" %}
+        <div class="field">
+          <label for="wiz-job-title">Job Title</label>
+          <input type="text" id="wiz-job-title" name="job_title" value="{{ form_data.get('job_title', '') }}" />
+          {% if field_errors.get("job_title") %}
+            <span class="error">{{ field_errors["job_title"][0] }}</span>
+          {% endif %}
+        </div>
+        <div class="field">
+          <label for="wiz-company">Company</label>
+          <input type="text" id="wiz-company" name="company" value="{{ form_data.get('company', '') }}" />
+          {% if field_errors.get("company") %}
+            <span class="error">{{ field_errors["company"][0] }}</span>
+          {% endif %}
+        </div>
+      {% endif %}
+
+      {# ---------- Step 3: Review ---------- #}
+      {% if step_key == "review" %}
+        <div class="review">
+          <p><strong>Name:</strong> {{ collected.get("contact", {}).get("name", "") }}</p>
+          <p><strong>Email:</strong> {{ collected.get("contact", {}).get("email", "") }}</p>
+          <p><strong>Job Title:</strong> {{ collected.get("target_role", {}).get("job_title", "") }}</p>
+          <p><strong>Company:</strong> {{ collected.get("target_role", {}).get("company", "") }}</p>
+        </div>
+      {% endif %}
+
+      {% if submitted and not is_valid %}
+        <div class="form-error">Please fix the errors above.</div>
+      {% endif %}
+
+      <div class="wizard-nav">
+        {% if step_index > 0 %}
+          <button
+            type="button"
+            hx-post="/components/resume_wizard"
+            hx-vals='js:{"event": "back", "payload": {}, "state": {{ state | tojson }}, "params": {"component_id": "{{ component_id }}"}}'
+            hx-target="#{{ component_id }}"
+            hx-swap="outerHTML"
+          >Back</button>
+        {% endif %}
+
+        {% if not is_last_step %}
+          {% if step_key == "contact" %}
+            <button
+              type="button"
+              hx-post="/components/resume_wizard"
+              hx-vals='js:{"event": "advance", "payload": {"form_data": {"name": document.getElementById("wiz-name").value, "email": document.getElementById("wiz-email").value}}, "state": {{ state | tojson }}, "params": {"component_id": "{{ component_id }}"}}'
+              hx-target="#{{ component_id }}"
+              hx-swap="outerHTML"
+            >Next</button>
+          {% elif step_key == "target_role" %}
+            <button
+              type="button"
+              hx-post="/components/resume_wizard"
+              hx-vals='js:{"event": "advance", "payload": {"form_data": {"job_title": document.getElementById("wiz-job-title").value, "company": document.getElementById("wiz-company").value}}, "state": {{ state | tojson }}, "params": {"component_id": "{{ component_id }}"}}'
+              hx-target="#{{ component_id }}"
+              hx-swap="outerHTML"
+            >Next</button>
+          {% endif %}
+        {% else %}
+          <button
+            type="button"
+            hx-post="/components/resume_wizard"
+            hx-vals='js:{"event": "submit", "payload": {"form_data": {}}, "state": {{ state | tojson }}, "params": {"component_id": "{{ component_id }}"}}'
+            hx-target="#{{ component_id }}"
+            hx-swap="outerHTML"
+          >Generate</button>
+        {% endif %}
+      </div>
+    </form>
+  {% endif %}
+</div>
+
+<style>
+.wizard {
+  padding: 20px;
+  border: 2px solid #333;
+  border-radius: 8px;
+  background: #f9f9f9;
+}
+.wizard-steps {
+  display: flex;
+  gap: 12px;
+  list-style: none;
+  padding: 0;
+  margin: 0 0 20px;
+}
+.wizard-steps li {
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: #e0e0e0;
+  font-size: 13px;
+  color: #666;
+}
+.wizard-steps li.active {
+  background: #1976d2;
+  color: white;
+  font-weight: 600;
+}
+.wizard-steps li.done {
+  background: #c8e6c9;
+  color: #2e7d32;
+}
+.wizard .field {
+  margin-bottom: 16px;
+}
+.wizard label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+.wizard input {
+  width: 100%;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 14px;
+  box-sizing: border-box;
+}
+.wizard .error {
+  color: #d32f2f;
+  font-size: 13px;
+}
+.wizard .form-error {
+  color: #d32f2f;
+  margin-top: 12px;
+  font-weight: 600;
+}
+.wizard-nav {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 20px;
+}
+.wizard-done {
+  text-align: center;
+}
+.wizard-done pre {
+  text-align: left;
+  background: white;
+  padding: 12px;
+  border-radius: 4px;
+}
+</style>


### PR DESCRIPTION
## Summary
- Closes #29 — adds a runnable multi-step wizard example for the FastAPI adapter (`examples/fastapi_wizard_example.py` + `templates/components/Wizard.jinja`) and a recipe writeup (`docs/examples/wizard.md`).
- The wizard is a single `FormComponent` subclass (`ResumeWizard`) that owns `step_index`/`collected` and swaps its active Pydantic schema per step via a `schema` property — there's no `CompositeComponent`-per-step primitive to build on, since that class doesn't actually exist in the codebase (only `fill_slot()`/`render_slots()`/`compose()` do). Flagged that doc/reality gap as a new item (H6) on Epic G (#27).
- Doc explicitly calls out that the state round-trip is unsigned until Epic A1 (#21) lands, and that the FastAPI adapter has no CSRF handling yet (A4) — both flagged as things to revisit once those epics ship.
- Filed sequenced follow-ups for the other adapters rather than scope-creeping this PR: Litestar (#30, near-mechanical port), Django (#31, needs CSRF/CBV/session design), Flask (#32, newest adapter, done last). Tracked under Epic D (#24) as D8.

## Test plan
- [x] `uv run pytest -q` — 420 passed, no regressions
- [x] `uv run ruff check` / `ruff format --check` on the new example — clean
- [x] Manually smoke-tested the component lifecycle (bad-email validation blocks advance, good advance stores collected data, back-navigation pre-fills, final submit completes) via `dispatch()` calls
- [ ] Manual browser run of `uv run python examples/fastapi_wizard_example.py` (not run in this environment — reviewer may want to click through it)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01KPACXz9tygw7WFoseMvE8A