### PR TITLE
feat(core): HMAC-sign client-carried state (A1, #21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **HMAC-signed client state (Epic A, A1 — #21)** — new stdlib-only
+  `core/signing.py` with `StateSigner` (HMAC-SHA256, versioned
+  `cfs1.<payload>.<mac>` token format) and `CorruptStateError`. Enable via
+  `StateSigner.configure(secret)` or the `STATE_SIGNING_KEY` environment
+  variable; comma-separated / sequence values enable key rotation (first key
+  signs, all keys verify). When enabled, all outbound state is signed and
+  inbound state must be a valid token — tampered, unsigned, or raw-dict state
+  is rejected with HTTP 400. When disabled, legacy plain-JSON behavior is
+  preserved and a one-time warning is logged. See `docs/STATE_SIGNING.md`.
+
+### Security
+
+- Closed the **dict bypass**: all adapters (FastAPI, Flask, Litestar, Django
+  FBV/CBV, WebSocket) now route inbound state through
+  `StateSerializer.load_untrusted()`, so a client can no longer submit state
+  as a raw JSON object to skip deserialization/verification.
+- Django `ComponentView.handle_error()` now maps client input errors
+  (`ValueError`, including corrupt state) to `400` instead of `500`.
+
 ## [0.5.0b0] - 2026-06-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -238,8 +238,9 @@ Generated from docstrings by pdoc and deployed to GitHub Pages on every push to 
 | [Architecture Overview](docs/server_component_spec.md) | Core design and component lifecycle |
 | [Django Implementation](docs/DJANGO_IMPLEMENTATION.md) | Django adapter setup and patterns |
 | [Class-Based Views](docs/CBV_GUIDE.md) | CBV auth/permission patterns |
+| [State Signing](docs/STATE_SIGNING.md) | HMAC-signed client state: setup per adapter + key rotation |
 | [E-Commerce Example](docs/examples/ecommerce.md) | Real-time cart + product demo |
-| [Multi-Step Wizard](docs/examples/wizard.md) | FastAPI wizard recipe (unsigned state — pending Epic A1) |
+| [Multi-Step Wizard](docs/examples/wizard.md) | FastAPI wizard recipe (enable [state signing](docs/STATE_SIGNING.md) in production) |
 | [CSRF & CSWSH Guide](docs/SECURITY_CSRF.md) | Per-adapter CSRF coverage audit + WebSocket hijacking guidance |
 
 ### AI / LLM Context
@@ -593,7 +594,7 @@ and [epic issues](https://github.com/fsecada01/component-framework/issues?q=is%3
 > optimistic UI once it lands).
 
 **0.6.0b — Hardening Foundation** *(Tier 0: security & rendering fidelity)*
-- [ ] Signed / tamper-proof state (HMAC) — *security gate*
+- [x] Signed / tamper-proof state (HMAC) — *security gate* — see [State Signing](docs/STATE_SIGNING.md)
 - [ ] DOM morphing — preserve focus / scroll / in-flight input; stable list keys
 - [ ] CSRF coverage for FastAPI / Litestar / Flask HTTP paths (today Django-only)
 - [ ] 422 re-render on form-validation failure (adapters currently return 200)

--- a/docs/STATE_SIGNING.md
+++ b/docs/STATE_SIGNING.md
@@ -1,0 +1,148 @@
+# State Signing (HMAC)
+
+Component state round-trips through the client on every dispatch: the server
+returns a serialized `state` field, and the client echoes it back with the
+next event. Without a signature, a client can tamper with any state field
+before echoing it back.
+
+State signing closes this gap. When enabled, every outbound state string is
+an HMAC-SHA256 signed token, and every inbound state **must** be a valid
+token — plain JSON strings and raw JSON objects are rejected with
+`CorruptStateError` (HTTP 400 on all adapters).
+
+## Token format
+
+```
+cfs1.<base64url(json_payload)>.<base64url(hmac_sha256_mac)>
+```
+
+The MAC covers `cfs1.<payload>` — the version prefix is bound into the
+signature, so tokens cannot be replayed across future format versions.
+
+## Enabling signing
+
+Signing is configured once per process, at application startup. There are two
+equivalent mechanisms:
+
+### 1. Environment variable (no code changes)
+
+```bash
+export STATE_SIGNING_KEY="$(openssl rand -hex 32)"
+```
+
+Comma-separated values enable key rotation (first key signs, all verify):
+
+```bash
+export STATE_SIGNING_KEY="new-key,old-key"
+```
+
+### 2. Explicit configuration
+
+```python
+from component_framework import StateSigner
+
+StateSigner.configure("your-secret-key")            # single key
+StateSigner.configure(["new-key", "old-key"])       # rotation
+StateSigner.configure(None)                          # explicitly disable (overrides env)
+```
+
+`StateSigner.configure()` takes precedence over the environment variable.
+
+If neither is set, signing is **disabled** and the framework falls back to
+legacy plain-JSON state — a one-time warning is logged. Do not run production
+deployments unsigned.
+
+## Per-adapter setup
+
+The signer is process-global and lives below the adapter layer, so setup is
+the same everywhere: configure it before the app starts serving.
+
+### FastAPI
+
+```python
+from fastapi import FastAPI
+from component_framework import StateSigner
+from component_framework.adapters.fastapi import create_component_routes
+
+StateSigner.configure(os.environ["MY_SECRET"])  # or just set STATE_SIGNING_KEY
+
+app = FastAPI()
+create_component_routes(app)
+```
+
+### Litestar
+
+```python
+from litestar import Litestar
+from component_framework import StateSigner
+from component_framework.adapters.litestar import component_endpoint
+
+StateSigner.configure(os.environ["MY_SECRET"])
+
+app = Litestar(route_handlers=[component_endpoint])
+```
+
+### Flask
+
+```python
+from flask import Flask
+from component_framework import StateSigner
+from component_framework.adapters.flask import register_component_routes
+
+app = Flask(__name__)
+StateSigner.configure(app.config["SECRET_KEY"])  # reusing SECRET_KEY is fine
+register_component_routes(app)
+```
+
+### Django
+
+Configure in `settings.py` (or an `AppConfig.ready()` hook):
+
+```python
+# settings.py
+from component_framework import StateSigner
+
+StateSigner.configure(SECRET_KEY)  # or a dedicated key
+```
+
+## Key rotation procedure
+
+1. **Prepend** the new key: `STATE_SIGNING_KEY="new-key,old-key"` (or
+   `StateSigner.configure(["new-key", "old-key"])`). New responses are signed
+   with `new-key`; states still in flight (signed with `old-key`) continue to
+   verify.
+2. **Wait** until in-flight client states have expired — i.e. long enough that
+   no open browser tab still holds a state signed with the old key. For most
+   apps a deploy cycle or a day is plenty.
+3. **Drop** the old key: `STATE_SIGNING_KEY="new-key"`. Old tokens now fail
+   verification (clients simply re-mount their components).
+
+## WebSocket pushes
+
+WebSocket traffic goes through the same `StateSerializer` choke point:
+inbound `component_event` messages are verified, and both dispatch responses
+and server-initiated `push_update()` broadcasts carry signed state.
+
+## Error handling
+
+Tampered, truncated, unsigned, or foreign-key state raises
+`component_framework.CorruptStateError` (a `ComponentError` subclass). The
+bundled adapters map it to:
+
+| Adapter | Response |
+|---------|----------|
+| FastAPI | `400` (`HTTPException`) |
+| Litestar | `400` (`HTTPException`) |
+| Flask | `400` JSON error |
+| Django (FBV + CBV) | `400` `JsonResponse` |
+| WebSocket | `{"type": "error", ...}` frame |
+
+## What signing does and does not protect
+
+- **Protects:** integrity — the client cannot alter state fields, forge
+  state, or splice state across format versions.
+- **Does not protect:** confidentiality — the payload is base64-encoded JSON,
+  readable by the client. Never put secrets in component state.
+- **Does not prevent replay of a stale-but-valid token** for the same
+  component. Treat state as untrusted input in handlers and enforce
+  authorization server-side (see Epic A3, locked fields, for the follow-up).

--- a/src/component_framework/__init__.py
+++ b/src/component_framework/__init__.py
@@ -1,0 +1,8 @@
+"""Component Framework — server-driven components for Python web frameworks."""
+
+from .core.signing import CorruptStateError, StateSigner
+
+__all__ = [
+    "CorruptStateError",
+    "StateSigner",
+]

--- a/src/component_framework/adapters/django_views.py
+++ b/src/component_framework/adapters/django_views.py
@@ -75,13 +75,11 @@ def component_view(request: HttpRequest, name: str) -> JsonResponse:
         except json.JSONDecodeError as e:
             return JsonResponse({"error": f"Invalid JSON in payload/params: {e}"}, status=400)
 
-        # Deserialize state
-        state = None
-        if state_str:
-            try:
-                state = StateSerializer.deserialize(state_str)
-            except Exception as e:
-                return JsonResponse({"error": f"Invalid state: {e}"}, status=400)
+        # Deserialize state (verified against the signing key when enabled)
+        try:
+            state = StateSerializer.load_untrusted(state_str)
+        except Exception as e:
+            return JsonResponse({"error": f"Invalid state: {e}"}, status=400)
 
         # Compute optimistic patch BEFORE dispatch (uses pre-dispatch state).
         # Hydrate state so get_optimistic_patch can access current state values.
@@ -254,12 +252,14 @@ class ComponentView(View):
         except json.JSONDecodeError as e:
             raise ValueError(f"Invalid payload JSON: {e}")
 
-    def parse_state(self, state_str: str | None) -> dict | None:
-        """Parse state JSON string."""
-        if not state_str:
-            return None
+    def parse_state(self, state_raw: str | dict | None) -> dict | None:
+        """Parse client-supplied state (signed token, JSON string, or dict).
+
+        Routes through :meth:`StateSerializer.load_untrusted` so raw dicts
+        cannot bypass signature verification when signing is enabled.
+        """
         try:
-            return StateSerializer.deserialize(state_str)
+            return StateSerializer.load_untrusted(state_raw)
         except Exception as e:
             raise ValueError(f"Invalid state: {e}")
 
@@ -304,7 +304,14 @@ class ComponentView(View):
         return JsonResponse({"error": f"Component '{name}' not found"}, status=404)
 
     def handle_error(self, error: Exception, name: str) -> JsonResponse:
-        """Handle errors."""
+        """Handle errors.
+
+        Client input errors (bad JSON, tampered/corrupt state) map to 400;
+        everything else maps to 500.
+        """
+        if isinstance(error, ValueError):
+            logger.warning("Bad request for component '%s': %s", name, error)
+            return JsonResponse({"error": str(error)}, status=400)
         logger.exception(f"Error processing component '{name}'")
         return JsonResponse({"error": "Internal server error"}, status=500)
 

--- a/src/component_framework/adapters/fastapi.py
+++ b/src/component_framework/adapters/fastapi.py
@@ -62,16 +62,10 @@ def _extract_params(data: dict) -> tuple[dict, str | None, dict, dict | None]:
     params = _parse_json_str(data.get("params"), default={}) or {}
     event = data.get("event")
     payload = _parse_json_str(data.get("payload"), default={}) or {}
-    state_raw = data.get("state")
-
-    state = None
-    if state_raw:
-        try:
-            state = (
-                StateSerializer.deserialize(state_raw) if isinstance(state_raw, str) else state_raw
-            )
-        except Exception as e:
-            raise HTTPException(status_code=400, detail=f"Invalid state: {e}")
+    try:
+        state = StateSerializer.load_untrusted(data.get("state"))
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Invalid state: {e}")
 
     return params, event, payload, state
 

--- a/src/component_framework/adapters/flask.py
+++ b/src/component_framework/adapters/flask.py
@@ -98,16 +98,10 @@ def _extract_params(data: dict) -> tuple[dict, str | None, dict, dict | None]:
     params = _parse_json_str(data.get("params"), default={}) or {}
     event = data.get("event")
     payload = _parse_json_str(data.get("payload"), default={}) or {}
-    state_raw = data.get("state")
-
-    state = None
-    if state_raw:
-        try:
-            state = (
-                StateSerializer.deserialize(state_raw) if isinstance(state_raw, str) else state_raw
-            )
-        except Exception as e:
-            raise ValueError(f"Invalid state: {e}")
+    try:
+        state = StateSerializer.load_untrusted(data.get("state"))
+    except Exception as e:
+        raise ValueError(f"Invalid state: {e}")
 
     return params, event, payload, state
 

--- a/src/component_framework/adapters/litestar.py
+++ b/src/component_framework/adapters/litestar.py
@@ -62,16 +62,10 @@ def _extract_params(data: dict) -> tuple[dict, str | None, dict, dict | None]:
     params = _parse_json_str(data.get("params"), default={}) or {}
     event = data.get("event")
     payload = _parse_json_str(data.get("payload"), default={}) or {}
-    state_raw = data.get("state")
-
-    state = None
-    if state_raw:
-        try:
-            state = (
-                StateSerializer.deserialize(state_raw) if isinstance(state_raw, str) else state_raw
-            )
-        except Exception as e:
-            raise HTTPException(status_code=400, detail=f"Invalid state: {e}")
+    try:
+        state = StateSerializer.load_untrusted(data.get("state"))
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Invalid state: {e}")
 
     return params, event, payload, state
 

--- a/src/component_framework/core/__init__.py
+++ b/src/component_framework/core/__init__.py
@@ -13,6 +13,7 @@ from .permissions import (
 )
 from .registry import ComponentRegistry, registry
 from .renderer import Renderer
+from .signing import CorruptStateError, StateSigner
 from .state import InMemoryStateStore, StateStore
 from .streaming import StreamingComponent, format_sse_frame
 from .websocket import ComponentWebSocketManager, WebSocketConnection, ws_manager
@@ -20,8 +21,10 @@ from .websocket import ComponentWebSocketManager, WebSocketConnection, ws_manage
 __all__ = [
     "Component",
     "ComponentError",
+    "CorruptStateError",
     "EventNotFoundError",
     "StateSerializer",
+    "StateSigner",
     "compose",
     "SlotRenderer",
     "FormComponent",

--- a/src/component_framework/core/component.py
+++ b/src/component_framework/core/component.py
@@ -343,6 +343,13 @@ class Component:
 class StateSerializer:
     """Handles safe serialization/deserialization of component state.
 
+    When state signing is enabled (see
+    :class:`~component_framework.core.signing.StateSigner`), outbound state is
+    HMAC-signed into a ``cfs1`` token and inbound state MUST be a valid signed
+    token — plain JSON strings and raw dicts from the client are rejected with
+    :class:`~component_framework.core.signing.CorruptStateError`. When signing
+    is disabled, legacy plain-JSON behavior applies (with a one-time warning).
+
     Class attributes:
         warn_bytes: Emit a warning when serialised state exceeds this size
             (default 64 KB).  Set to ``0`` to disable warnings.
@@ -355,11 +362,15 @@ class StateSerializer:
 
     @staticmethod
     def serialize(state: dict) -> str:
-        """Serialize state to JSON string.
+        """Serialize state to a JSON string, signing it when enabled.
 
-        Emits a warning if the result exceeds :attr:`warn_bytes` and raises
-        :class:`ComponentError` if it exceeds :attr:`max_bytes`.
+        Emits a warning if the raw JSON exceeds :attr:`warn_bytes` and raises
+        :class:`ComponentError` if it exceeds :attr:`max_bytes` (size guards
+        always operate on the unsigned JSON).
         """
+        # Local import: signing imports ComponentError from this module.
+        from .signing import StateSigner
+
         serialized = json.dumps(state, default=str)
         size = len(serialized)
 
@@ -379,11 +390,71 @@ class StateSerializer:
                 f"{StateSerializer.warn_bytes:,}",
             )
 
+        if StateSigner.enabled():
+            return StateSigner.sign(serialized)
+
+        StateSigner.warn_unsigned_once()
         return serialized
 
     @staticmethod
     def deserialize(data: str) -> dict:
-        """Deserialize state from JSON string."""
+        """Deserialize state from a JSON string or signed ``cfs1`` token.
+
+        When signing is enabled, *data* must be a valid signed token;
+        anything else raises
+        :class:`~component_framework.core.signing.CorruptStateError`.
+        """
+        from .signing import CorruptStateError, StateSigner
+
         if not data:
             return {}
+
+        if StateSigner.enabled():
+            payload = StateSigner.verify(data)
+            try:
+                parsed = json.loads(payload)
+            except (json.JSONDecodeError, ValueError) as e:
+                raise CorruptStateError("Signed state payload is not valid JSON") from e
+            if not isinstance(parsed, dict):
+                raise CorruptStateError("Signed state payload is not a JSON object")
+            return parsed
+
         return json.loads(data)
+
+    @classmethod
+    def load_untrusted(cls, raw: "str | dict | None") -> dict | None:
+        """Single inbound entry point for client-supplied state.
+
+        Adapters MUST route all inbound state through this method so that raw
+        dicts cannot bypass signature verification.
+
+        Args:
+            raw: Client-supplied state — a signed token, a JSON string, a raw
+                dict (legacy clients only), or None/empty.
+
+        Returns:
+            The state dict, or None when *raw* is empty/absent.
+
+        Raises:
+            CorruptStateError: When signing is enabled and *raw* is not a
+                valid signed token (including raw dicts and plain JSON).
+            json.JSONDecodeError: When signing is disabled and *raw* is an
+                invalid JSON string (legacy behavior).
+        """
+        from .signing import CorruptStateError, StateSigner
+
+        if not raw:
+            return None
+
+        if StateSigner.enabled():
+            if not isinstance(raw, str):
+                raise CorruptStateError(
+                    "State signing is enabled: state must be a signed token "
+                    f"string, got {type(raw).__name__}"
+                )
+            return cls.deserialize(raw)
+
+        # Legacy (unsigned) behavior: dicts pass through, strings are parsed.
+        if isinstance(raw, dict):
+            return raw
+        return cls.deserialize(raw)

--- a/src/component_framework/core/signing.py
+++ b/src/component_framework/core/signing.py
@@ -1,0 +1,232 @@
+"""HMAC-SHA256 signing for client-carried component state.
+
+Component state round-trips through the client on every dispatch. Without a
+signature, the client can tamper with any state field before echoing it back.
+This module signs outbound state and verifies inbound state at the
+:class:`~component_framework.core.component.StateSerializer` choke point, so
+every adapter (FastAPI, Flask, Litestar, Django, WebSocket) is covered.
+
+Token format (version ``cfs1``)::
+
+    cfs1.<base64url_nopad(json_payload)>.<base64url_nopad(hmac_sha256_mac)>
+
+The MAC covers ``b"cfs1." + payload_b64`` so a token can never be confused
+with (or replayed into) a future format version.
+
+Enable signing by calling :meth:`StateSigner.configure` at application start,
+or by setting the ``STATE_SIGNING_KEY`` environment variable. Both accept
+multiple keys for rotation (a sequence for ``configure``, comma-separated for
+the env var): the FIRST key signs new tokens, ALL keys verify inbound tokens.
+
+Uses only the standard library (hmac, hashlib, base64, os).
+"""
+
+import base64
+import binascii
+import hashlib
+import hmac
+import logging
+import os
+from collections.abc import Sequence
+from typing import ClassVar
+
+from .component import ComponentError
+
+logger = logging.getLogger(__name__)
+
+ENV_VAR = "STATE_SIGNING_KEY"
+TOKEN_VERSION = "cfs1"
+
+SecretInput = str | bytes | Sequence[str | bytes] | None
+
+
+class CorruptStateError(ComponentError):
+    """Raised when inbound state fails signature verification.
+
+    Covers tampered payloads, tampered/invalid MACs, malformed or truncated
+    tokens, unsigned input (plain JSON or raw dicts) while signing is
+    enabled, and tokens signed with an unknown key.
+    """
+
+
+def _b64url_encode(data: bytes) -> str:
+    """Encode bytes as unpadded URL-safe base64."""
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(data: str) -> bytes:
+    """Decode unpadded URL-safe base64 back to bytes."""
+    padding = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + padding)
+
+
+class StateSigner:
+    """HMAC-SHA256 signer/verifier for serialized component state.
+
+    Key resolution order:
+        1. Keys set via :meth:`configure` (including an explicit ``None`` to
+           disable signing regardless of the environment).
+        2. The ``STATE_SIGNING_KEY`` environment variable (comma-separated
+           values enable rotation).
+        3. Nothing configured: signing is disabled (legacy pass-through) and
+           a one-time warning is logged on first serialization.
+
+    Rotation: the first key signs, all keys verify. To rotate, prepend the
+    new key, keep the old key until in-flight client states have expired,
+    then drop it.
+    """
+
+    _keys: ClassVar[tuple[bytes, ...] | None] = None
+    _configured: ClassVar[bool] = False
+    _warned_unsigned: ClassVar[bool] = False
+
+    # ---------- Configuration ----------
+
+    @classmethod
+    def configure(cls, secret: SecretInput) -> None:
+        """Configure signing keys.
+
+        Args:
+            secret: A single key (``str`` or ``bytes``), a sequence of keys
+                for rotation (first signs, all verify), or ``None`` to
+                explicitly disable signing (overrides the environment
+                variable).
+
+        Raises:
+            ValueError: If a key is empty or an empty sequence is given.
+        """
+        cls._keys = None if secret is None else cls._normalize(secret)
+        cls._configured = True
+        cls._warned_unsigned = False
+
+    @classmethod
+    def reset(cls) -> None:
+        """Reset to the unconfigured default (env-var fallback).
+
+        Intended for tests and application teardown.
+        """
+        cls._keys = None
+        cls._configured = False
+        cls._warned_unsigned = False
+
+    @classmethod
+    def enabled(cls) -> bool:
+        """Return True when at least one signing key is available."""
+        return bool(cls._resolve_keys())
+
+    @classmethod
+    def _normalize(cls, secret: str | bytes | Sequence[str | bytes]) -> tuple[bytes, ...]:
+        """Normalize a secret (or sequence of secrets) into key bytes."""
+        raw: Sequence[str | bytes]
+        raw = [secret] if isinstance(secret, (str, bytes)) else list(secret)
+        if not raw:
+            raise ValueError("StateSigner.configure() requires at least one signing key")
+        keys: list[bytes] = []
+        for item in raw:
+            key = item.encode("utf-8") if isinstance(item, str) else bytes(item)
+            if not key:
+                raise ValueError("Signing keys must be non-empty")
+            keys.append(key)
+        return tuple(keys)
+
+    @classmethod
+    def _resolve_keys(cls) -> tuple[bytes, ...] | None:
+        """Resolve active keys from explicit config or the environment."""
+        if cls._configured:
+            return cls._keys
+        env_value = os.environ.get(ENV_VAR, "")
+        parts = [part.strip() for part in env_value.split(",") if part.strip()]
+        if not parts:
+            return None
+        return tuple(part.encode("utf-8") for part in parts)
+
+    # ---------- Signing / verification ----------
+
+    @classmethod
+    def sign(cls, payload_json: str) -> str:
+        """Sign a JSON payload string into a ``cfs1`` token.
+
+        Args:
+            payload_json: The serialized (JSON) state to protect.
+
+        Returns:
+            A ``cfs1.<payload_b64>.<mac_b64>`` token string.
+
+        Raises:
+            ComponentError: If no signing key is configured.
+        """
+        keys = cls._resolve_keys()
+        if not keys:
+            raise ComponentError("StateSigner.sign() called but no signing key is configured")
+        payload_b64 = _b64url_encode(payload_json.encode("utf-8"))
+        mac = hmac.new(keys[0], cls._signing_input(payload_b64), hashlib.sha256).digest()
+        return f"{TOKEN_VERSION}.{payload_b64}.{_b64url_encode(mac)}"
+
+    @classmethod
+    def verify(cls, token: str) -> str:
+        """Verify a ``cfs1`` token and return the embedded JSON payload.
+
+        All configured keys are tried (rotation support), using
+        :func:`hmac.compare_digest` for constant-time comparison.
+
+        Args:
+            token: The inbound token string.
+
+        Returns:
+            The verified JSON payload string.
+
+        Raises:
+            CorruptStateError: If the token is malformed, unsigned, tampered
+                with, or signed with an unknown key.
+            ComponentError: If no signing key is configured.
+        """
+        keys = cls._resolve_keys()
+        if not keys:
+            raise ComponentError("StateSigner.verify() called but no signing key is configured")
+
+        if not isinstance(token, str):
+            raise CorruptStateError(
+                f"Signed state token must be a string, got {type(token).__name__}"
+            )
+
+        parts = token.split(".")
+        if len(parts) != 3 or parts[0] != TOKEN_VERSION:
+            raise CorruptStateError("State token is malformed or unsigned")
+        _, payload_b64, mac_b64 = parts
+
+        try:
+            provided_mac = _b64url_decode(mac_b64)
+        except (binascii.Error, ValueError) as e:
+            raise CorruptStateError("State token MAC is not valid base64") from e
+
+        signing_input = cls._signing_input(payload_b64)
+        for key in keys:
+            expected_mac = hmac.new(key, signing_input, hashlib.sha256).digest()
+            if hmac.compare_digest(expected_mac, provided_mac):
+                try:
+                    return _b64url_decode(payload_b64).decode("utf-8")
+                except (binascii.Error, ValueError, UnicodeDecodeError) as e:
+                    raise CorruptStateError("State token payload is not decodable") from e
+
+        raise CorruptStateError("State signature verification failed")
+
+    @staticmethod
+    def _signing_input(payload_b64: str) -> bytes:
+        """Build the MAC input, binding the version prefix to the payload."""
+        return f"{TOKEN_VERSION}.{payload_b64}".encode("ascii")
+
+    # ---------- Diagnostics ----------
+
+    @classmethod
+    def warn_unsigned_once(cls) -> None:
+        """Log a one-time prominent warning that state is unsigned."""
+        if cls._warned_unsigned:
+            return
+        cls._warned_unsigned = True
+        logger.warning(
+            "SECURITY: component state signing is DISABLED — client-carried "
+            "state is unsigned and can be tampered with. Set the "
+            "%s environment variable or call StateSigner.configure() "
+            "with a secret key before deploying to production.",
+            ENV_VAR,
+        )

--- a/src/component_framework/core/websocket.py
+++ b/src/component_framework/core/websocket.py
@@ -116,7 +116,7 @@ class ComponentWebSocketManager:
             component_id: str | None = message.get("component_id")
             event: str | None = message.get("event")
             payload: dict = message.get("payload", {})
-            state_str: str | None = message.get("state")
+            state_str: str | dict | None = message.get("state")
 
             # Get component class
             component_cls = registry.get(component_name)
@@ -129,10 +129,8 @@ class ComponentWebSocketManager:
                 )
                 return
 
-            # Deserialize state
-            state = None
-            if state_str:
-                state = StateSerializer.deserialize(state_str)
+            # Deserialize state (verified against the signing key when enabled)
+            state = StateSerializer.load_untrusted(state_str)
 
             # Create and dispatch component (async to support async on_* handlers)
             params = {"component_id": component_id}

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -1,0 +1,332 @@
+"""Tests for HMAC state signing (Epic A, task A1)."""
+
+import base64
+import json
+import logging
+
+import pytest
+
+from component_framework.core.component import ComponentError, StateSerializer
+from component_framework.core.signing import CorruptStateError, StateSigner
+
+
+@pytest.fixture(autouse=True)
+def _reset_signer(monkeypatch):
+    """Isolate signer configuration per test (env + class state)."""
+    monkeypatch.delenv("STATE_SIGNING_KEY", raising=False)
+    StateSigner.reset()
+    yield
+    StateSigner.reset()
+
+
+# ---------- Basic sign/verify ----------
+
+
+class TestSignVerifyRoundTrip:
+    def test_round_trip_preserves_state(self):
+        StateSigner.configure("secret-key")
+        state = {"count": 3, "name": "widget", "nested": {"a": [1, 2]}}
+        token = StateSerializer.serialize(state)
+        assert token.startswith("cfs1.")
+        assert StateSerializer.deserialize(token) == state
+
+    def test_token_has_three_segments(self):
+        StateSigner.configure("secret-key")
+        token = StateSerializer.serialize({"x": 1})
+        assert len(token.split(".")) == 3
+
+    def test_empty_state_round_trip(self):
+        StateSigner.configure("secret-key")
+        token = StateSerializer.serialize({})
+        assert token.startswith("cfs1.")
+        assert StateSerializer.deserialize(token) == {}
+
+    def test_corrupt_state_error_is_component_error(self):
+        assert issubclass(CorruptStateError, ComponentError)
+
+
+# ---------- Tampering ----------
+
+
+class TestTamperRejection:
+    def _make_token(self, state: dict) -> str:
+        StateSigner.configure("secret-key")
+        return StateSerializer.serialize(state)
+
+    def test_tampered_payload_rejected(self):
+        token = self._make_token({"count": 1})
+        version, _payload, mac = token.split(".")
+        # Substitute a different (validly encoded) payload, keep the old MAC.
+        forged_payload = (
+            base64.urlsafe_b64encode(json.dumps({"count": 999}).encode()).rstrip(b"=").decode()
+        )
+        forged = f"{version}.{forged_payload}.{mac}"
+        with pytest.raises(CorruptStateError):
+            StateSerializer.deserialize(forged)
+
+    def test_tampered_mac_rejected(self):
+        token = self._make_token({"count": 1})
+        flipped = token[:-1] + ("A" if token[-1] != "A" else "B")
+        with pytest.raises(CorruptStateError):
+            StateSerializer.deserialize(flipped)
+
+    def test_truncated_token_rejected(self):
+        token = self._make_token({"count": 1})
+        with pytest.raises(CorruptStateError):
+            StateSerializer.deserialize(token[: len(token) // 2])
+
+    def test_garbage_token_rejected(self):
+        self._make_token({"count": 1})
+        with pytest.raises(CorruptStateError):
+            StateSerializer.deserialize("total.garbage.here")
+
+    def test_wrong_version_prefix_rejected(self):
+        token = self._make_token({"count": 1})
+        with pytest.raises(CorruptStateError):
+            StateSerializer.deserialize("cfs2." + token.split(".", 1)[1])
+
+    def test_wrong_key_rejected(self):
+        token = self._make_token({"count": 1})
+        StateSigner.configure("a-different-key")
+        with pytest.raises(CorruptStateError):
+            StateSerializer.deserialize(token)
+
+
+# ---------- Unsigned input while enabled ----------
+
+
+class TestUnsignedInputRejectedWhenEnabled:
+    def test_plain_json_string_rejected(self):
+        StateSigner.configure("secret-key")
+        with pytest.raises(CorruptStateError):
+            StateSerializer.deserialize('{"count": 999}')
+
+    def test_plain_json_string_rejected_via_load_untrusted(self):
+        StateSigner.configure("secret-key")
+        with pytest.raises(CorruptStateError):
+            StateSerializer.load_untrusted('{"count": 999}')
+
+    def test_raw_dict_rejected_via_load_untrusted(self):
+        StateSigner.configure("secret-key")
+        with pytest.raises(CorruptStateError):
+            StateSerializer.load_untrusted({"count": 999})
+
+
+# ---------- Key rotation ----------
+
+
+class TestKeyRotation:
+    def test_old_token_verifies_after_new_key_prepended(self):
+        StateSigner.configure("old-key")
+        old_token = StateSerializer.serialize({"count": 7})
+
+        StateSigner.configure(["new-key", "old-key"])
+        assert StateSerializer.deserialize(old_token) == {"count": 7}
+
+    def test_new_tokens_signed_with_first_key(self):
+        StateSigner.configure(["new-key", "old-key"])
+        token = StateSerializer.serialize({"count": 7})
+
+        # A signer holding only the new key must accept it...
+        StateSigner.configure("new-key")
+        assert StateSerializer.deserialize(token) == {"count": 7}
+
+        # ...and one holding only the old key must reject it.
+        StateSigner.configure("old-key")
+        with pytest.raises(CorruptStateError):
+            StateSerializer.deserialize(token)
+
+    def test_dropping_old_key_invalidates_old_tokens(self):
+        StateSigner.configure("old-key")
+        old_token = StateSerializer.serialize({"count": 7})
+        StateSigner.configure(["new-key"])
+        with pytest.raises(CorruptStateError):
+            StateSerializer.deserialize(old_token)
+
+    def test_bytes_keys_accepted(self):
+        StateSigner.configure(b"binary-key")
+        token = StateSerializer.serialize({"ok": True})
+        assert StateSerializer.deserialize(token) == {"ok": True}
+
+    def test_empty_key_rejected(self):
+        with pytest.raises(ValueError):
+            StateSigner.configure("")
+
+    def test_empty_key_list_rejected(self):
+        with pytest.raises(ValueError):
+            StateSigner.configure([])
+
+
+# ---------- Disabled (legacy) mode ----------
+
+
+class TestDisabledMode:
+    def test_serialize_returns_plain_json(self):
+        result = StateSerializer.serialize({"count": 1})
+        assert json.loads(result) == {"count": 1}
+        assert not result.startswith("cfs1.")
+
+    def test_deserialize_plain_json(self):
+        assert StateSerializer.deserialize('{"count": 1}') == {"count": 1}
+
+    def test_load_untrusted_str_parses_json(self):
+        assert StateSerializer.load_untrusted('{"count": 1}') == {"count": 1}
+
+    def test_load_untrusted_dict_passes_through(self):
+        state = {"count": 1}
+        assert StateSerializer.load_untrusted(state) == state
+
+    def test_load_untrusted_none_and_empty(self):
+        assert StateSerializer.load_untrusted(None) is None
+        assert StateSerializer.load_untrusted("") is None
+
+    def test_configure_none_disables_even_with_env(self, monkeypatch):
+        monkeypatch.setenv("STATE_SIGNING_KEY", "env-key")
+        StateSigner.configure(None)
+        assert not StateSigner.enabled()
+        result = StateSerializer.serialize({"count": 1})
+        assert json.loads(result) == {"count": 1}
+
+    def test_unsigned_warning_emitted_once(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="component_framework.core.signing"):
+            StateSerializer.serialize({"a": 1})
+            StateSerializer.serialize({"b": 2})
+        unsigned_warnings = [r for r in caplog.records if "unsigned" in r.getMessage().lower()]
+        assert len(unsigned_warnings) == 1
+
+
+# ---------- Environment variable pickup ----------
+
+
+class TestEnvVarConfiguration:
+    def test_env_var_enables_signing(self, monkeypatch):
+        monkeypatch.setenv("STATE_SIGNING_KEY", "env-secret")
+        assert StateSigner.enabled()
+        token = StateSerializer.serialize({"count": 1})
+        assert token.startswith("cfs1.")
+        assert StateSerializer.deserialize(token) == {"count": 1}
+
+    def test_env_var_comma_separated_rotation(self, monkeypatch):
+        monkeypatch.setenv("STATE_SIGNING_KEY", "old-env-key")
+        old_token = StateSerializer.serialize({"count": 5})
+
+        monkeypatch.setenv("STATE_SIGNING_KEY", "new-env-key,old-env-key")
+        assert StateSerializer.deserialize(old_token) == {"count": 5}
+
+        new_token = StateSerializer.serialize({"count": 6})
+        monkeypatch.setenv("STATE_SIGNING_KEY", "new-env-key")
+        assert StateSerializer.deserialize(new_token) == {"count": 6}
+
+    def test_configure_takes_precedence_over_env(self, monkeypatch):
+        monkeypatch.setenv("STATE_SIGNING_KEY", "env-key")
+        StateSigner.configure("explicit-key")
+        token = StateSerializer.serialize({"count": 1})
+        monkeypatch.delenv("STATE_SIGNING_KEY")
+        StateSigner.reset()
+        StateSigner.configure("explicit-key")
+        assert StateSerializer.deserialize(token) == {"count": 1}
+
+
+# ---------- Exports ----------
+
+
+class TestExports:
+    def test_core_exports(self):
+        import component_framework.core as core
+
+        assert core.CorruptStateError is CorruptStateError
+        assert core.StateSigner is StateSigner
+
+    def test_root_exports(self):
+        import component_framework
+
+        assert component_framework.CorruptStateError is CorruptStateError
+        assert component_framework.StateSigner is StateSigner
+        assert "CorruptStateError" in component_framework.__all__
+        assert "StateSigner" in component_framework.__all__
+
+
+# ---------- FastAPI adapter integration ----------
+
+
+class TestFastAPIIntegration:
+    @pytest.fixture
+    def client(self, monkeypatch):
+        fastapi = pytest.importorskip("fastapi")
+        from fastapi.testclient import TestClient
+
+        from component_framework.adapters.fastapi import create_component_routes
+        from component_framework.core import Component, Renderer
+        from component_framework.core.registry import ComponentRegistry
+
+        class MockRenderer(Renderer):
+            def render(self, template_name: str, context: dict) -> str:
+                return f"<div>{context.get('state', {})}</div>"
+
+        old_renderer = Component.renderer
+        Component.renderer = MockRenderer()
+
+        reg = ComponentRegistry()
+        monkeypatch.setattr("component_framework.adapters.fastapi.registry", reg)
+
+        @reg.register("signed_counter")
+        class SignedCounter(Component):
+            template_name = "counter.html"
+
+            def mount(self):
+                super().mount()
+                self.state["count"] = 0
+
+            def on_increment(self, amount: int = 1):
+                self.state["count"] = self.state.get("count", 0) + amount
+
+        app = fastapi.FastAPI()
+        create_component_routes(app)
+        yield TestClient(app)
+        Component.renderer = old_renderer
+
+    def test_success_path_returns_signed_state(self, client):
+        StateSigner.configure("adapter-secret")
+        response = client.post("/components/signed_counter", json={})
+        assert response.status_code == 200
+        assert response.json()["state"].startswith("cfs1.")
+
+    def test_signed_round_trip_through_endpoint(self, client):
+        StateSigner.configure("adapter-secret")
+        r1 = client.post("/components/signed_counter", json={})
+        state_token = r1.json()["state"]
+
+        r2 = client.post(
+            "/components/signed_counter",
+            json={"event": "increment", "payload": {"amount": 3}, "state": state_token},
+        )
+        assert r2.status_code == 200
+        assert StateSerializer.deserialize(r2.json()["state"]) == {"count": 3}
+
+    def test_tampered_state_returns_400(self, client):
+        StateSigner.configure("adapter-secret")
+        r1 = client.post("/components/signed_counter", json={})
+        token = r1.json()["state"]
+        tampered = token[:-2] + ("aa" if not token.endswith("aa") else "bb")
+
+        r2 = client.post(
+            "/components/signed_counter",
+            json={"event": "increment", "payload": {}, "state": tampered},
+        )
+        assert r2.status_code == 400
+
+    def test_raw_dict_state_returns_400(self, client):
+        StateSigner.configure("adapter-secret")
+        r2 = client.post(
+            "/components/signed_counter",
+            json={"event": "increment", "payload": {}, "state": {"count": 999}},
+        )
+        assert r2.status_code == 400
+
+    def test_plain_json_string_state_returns_400(self, client):
+        StateSigner.configure("adapter-secret")
+        r2 = client.post(
+            "/components/signed_counter",
+            json={"event": "increment", "payload": {}, "state": '{"count": 999}'},
+        )
+        assert r2.status_code == 400


### PR DESCRIPTION
## Summary

Implements **A1 — HMAC state signing** from Epic A (#21, milestone 0.6.0b), the security gate for 0.6.0b: component state currently round-trips to the client **unsigned**, letting a client tamper with any state field before echoing it back.

- **New stdlib-only `core/signing.py`** — `StateSigner` (HMAC-SHA256) + `CorruptStateError` (a `ComponentError` subclass). Versioned token format `cfs1.<b64url(payload)>.<b64url(mac)>`; the MAC signs over `b"cfs1." + payload_b64` so tokens can't be confused across format versions. Verification uses `hmac.compare_digest`.
- **Key configuration** — `StateSigner.configure(secret)` (str / bytes / sequence / `None`) or the `STATE_SIGNING_KEY` env var (comma-separated for rotation). **Rotation groundwork for A2:** first key signs, all keys verify — prepend the new key, drop the old one once in-flight states expire.
- **Integrated at the `StateSerializer` choke point** — size guards still operate on the raw JSON; the result is signed when enabled. Inbound verification happens in `deserialize()` / the new `load_untrusted()` classmethod.
- **Closed the dict bypass** — every adapter previously did `deserialize(raw) if isinstance(raw, str) else raw`, so a client could submit state as a raw JSON object and skip verification entirely. All inbound call sites (FastAPI, Flask, Litestar, Django FBV + CBV, WebSocket manager) now route through `StateSerializer.load_untrusted()`. With signing enabled, raw dicts and plain JSON strings are rejected (HTTP 400); disabled mode preserves legacy behavior exactly.
- **HTTP mapping** — tampered/corrupt state surfaces as 400 on all adapters. Django's CBV `handle_error()` previously mapped `ValueError` (bad payload/state) to 500; it now returns 400, matching the FBV and the other adapters.
- **Disabled mode** (no key) — legacy pass-through with a one-time prominent warning that state is unsigned.
- **Docs (covers the A2 doc scope)** — `docs/STATE_SIGNING.md`: per-adapter setup, rotation procedure, WS-push coverage note, threat-model caveats. README docs table + roadmap and CHANGELOG updated.
- **Exports** — `StateSigner` / `CorruptStateError` from `component_framework`, `component_framework.core`.

## Test plan

- [x] 36 new tests in `tests/test_signing.py` (TDD): sign/verify round-trip, tampered payload / tampered MAC / truncated / garbage / wrong-version / wrong-key rejection, plain-JSON and raw-dict rejection while enabled, key rotation (old token verifies after prepend; new tokens signed with new key; dropping old key invalidates), env-var pickup incl. comma-separated rotation, `configure(None)` override, disabled-mode legacy parity, empty/None state, one-time unsigned warning, export surface, and FastAPI adapter integration (signed `cfs1.` state on success, 400 on tampered/dict/plain-JSON state).
- [x] Full suite: **456 passed** (420 pre-existing + 36 new) — zero regressions.
- [x] `ruff check` + `ruff format --check` clean; `ty check` diagnostics unchanged from master baseline (17 pre-existing, none in touched code).
- [x] Test isolation: autouse fixture resets `StateSigner` per test; the existing suite runs with signing disabled by default.

Refs #21 — implements A1 and lays the rotation groundwork for A2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)