### PR TITLE
chore(release): 0.6.0 stable, trusted publishing, and a package fit to hand to someone (#47, #49)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,39 @@ jobs:
           echo "pyproject: $declared / tag: $tagged"
           test "$declared" = "$tagged"
 
+      # The package is not only Python. The client JS, its vendored Idiomorph
+      # copy, the stylesheet, and the PEP 561 marker all live inside the
+      # package so hatchling picks them up with no explicit include — which is
+      # exactly what would make a regression here quiet. A wheel missing
+      # component-client.js installs and imports cleanly and then serves no
+      # interactivity; a wheel missing py.typed types as `Any` everywhere with
+      # no error at all.
+      - name: Wheel must contain the client assets and the typing marker
+        run: |
+          python - <<'PY'
+          import pathlib, sys, zipfile
+
+          wheel = next(iter(sorted(pathlib.Path("dist").glob("*.whl"))))
+          names = zipfile.ZipFile(wheel).namelist()
+          print(f"{wheel.name}: {len(names)} entries")
+
+          missing = [
+              required
+              for required in [
+                  "component_framework/py.typed",
+                  "component_framework/static/component_framework/js/component-client.js",
+                  "component_framework/static/component_framework/js/component-client.d.ts",
+                  "component_framework/static/component_framework/js/vendor/idiomorph.js",
+                  "component_framework/static/component_framework/css/component-framework.css",
+              ]
+              if not any(n.endswith(required) for n in names)
+          ]
+          if missing:
+              sys.exit("wheel is missing shipped content:\n  " + "\n  ".join(missing))
+
+          print("ok: client assets and py.typed present")
+          PY
+
       - uses: actions/upload-artifact@v4
         with:
           name: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      # Catches a malformed README or broken metadata before anything is
+      # uploaded — a bad upload cannot be replaced, only yanked.
+      - name: Validate distributions
+        run: uvx twine check dist/*
+
+      # The tag is the release's identity; if it disagrees with the version in
+      # pyproject.toml the wheel would be published under a name the tag does
+      # not describe. Fail here rather than after upload.
+      - name: Tag must match the declared version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          declared=$(python -c "import tomllib,pathlib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")
+          tagged="${GITHUB_REF_NAME#v}"
+          echo "pyproject: $declared / tag: $tagged"
+          test "$declared" = "$tagged"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    # Gates the upload behind a named environment, so protection rules can
+    # require a review before anything reaches PyPI.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/component-framework
+    permissions:
+      # Required for trusted publishing: the job mints a short-lived OIDC
+      # token that PyPI exchanges for an upload token. No API token is stored.
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.0] - 2026-07-30
 
-First release published to PyPI. No code changes from `0.6.0b0` — the beta is
-promoted to a final release so that dependents can require a stable version.
-`cf-ui` declares `component-framework>=0.4`, and a specifier without a
-pre-release marker only resolves to a pre-release when no final release exists;
-relying on that fallback would mean the resolution changed silently the first
-time any stable version appeared.
+First release published to PyPI. No behavioural change from `0.6.0b0` — the
+beta is promoted to a final release so that dependents can require a stable
+version. `cf-ui` declares `component-framework>=0.4`, and a specifier without
+a pre-release marker only resolves to a pre-release when no final release
+exists; relying on that fallback would mean the resolution changed silently
+the first time any stable version appeared.
+
+The rest of this entry is what an audit of the built wheel turned up: the
+package was installable, but not yet fit to *hand to someone*.
 
 ### Added
 
 - Trusted publishing to PyPI via GitHub Actions OIDC on a `v*` tag (#47). No
-  API token is stored in the repository.
+  API token is stored in the repository. The build job also refuses to hand
+  off a wheel missing the client assets or `py.typed` — those ship inside the
+  package with no explicit include, so a packaging regression would produce a
+  wheel that installs and imports cleanly and then serves no interactivity.
+- **`py.typed` (#49).** The codebase is type-checked in CI and ships
+  `component-client.d.ts` for the JS, but without the PEP 561 marker every
+  Python consumer running mypy or pyright saw the whole package as untyped.
+  The types existed; they were not advertised.
+- **A `testing` extra (#49)** declaring pytest.
+  `component_framework.testing` imports pytest at module scope — it ships
+  fixtures and a pytest-style base class — but pytest was only reachable via
+  `dev-base`, so following the README's testing sample after
+  `pip install component-framework[fastapi]` raised `ModuleNotFoundError`.
+- **Classifiers** for the license (which is what PyPI's sidebar reads), the
+  frameworks the adapters target, and `Typing :: Typed`.
+
+### Fixed — documentation that did not survive contact with the package (#49)
+
+Found by building the wheel, installing it into a clean venv, and checking
+every documented import against the *installed* package rather than the
+source tree.
+
+- **The README described an install nobody could perform.** Every instruction
+  was `pip install -e ".[extra]"` — an editable install from a checkout — and
+  the section opened with "Not on PyPI yet". The README *is* the PyPI landing
+  page, so the one line a visitor arriving there needed was the one that was
+  missing. It now leads with `pip install "component-framework[fastapi]"`,
+  documents the quoting (bare brackets are glob syntax in zsh), shows the
+  missing-extra `ImportError` a reader will actually meet, and demotes the
+  editable install to a contributor note.
+- **The README's composition example was invented.** It imported
+  `SlotComponent` and `CompositeComponent` from `core.composition`, which
+  exports neither, and set a `components = {...}` attribute nothing reads.
+  The real API is a `Component` with a `slots` ClassVar, assembled with
+  `compose()`.
+- **The README's testing example used methods that do not exist**
+  (`mount_component`, `dispatch_event`, and `assert_state` with a positional
+  component argument), and omitted the required `component_class`.
+- **`docs/LOCKED_FIELDS.md`** imported `Component` and `registry` from the
+  top-level package, which exports only `CorruptStateError` and
+  `StateSigner`.
+- **`docs/CBV_GUIDE.md`** imported `RateLimitMixin` from
+  `adapters.django_views`; it lives in `adapters.django_ratelimit`, as the
+  README said all along.
+- **Two `docs/examples/ecommerce.md` samples did not parse** — a bare `...`
+  inside a list literal, and a method whose body was only a comment.
+
+### Added — a test that reads the docs (#49)
+
+`tests/test_docs_samples.py` parses every fenced `python` block in the
+README, CONTRIBUTING, and `docs/`, and resolves every
+`from component_framework… import …` against the real package. Nothing here
+read the documentation before, which is why all six defects above shipped;
+the guard goes red on every one of them when run against the previous text.
+It also fails if the README ever again claims the package is not on PyPI.
+Ported from cf-ui's `test_docs_samples.py`, which exists because
+`ComponentCatalog` and `<CfCard>` sat in *that* README for two releases.
 
 ## [0.6.0b0] - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-30
+
+First release published to PyPI. No code changes from `0.6.0b0` — the beta is
+promoted to a final release so that dependents can require a stable version.
+`cf-ui` declares `component-framework>=0.4`, and a specifier without a
+pre-release marker only resolves to a pre-release when no final release exists;
+relying on that fallback would mean the resolution changed silently the first
+time any stable version appeared.
+
+### Added
+
+- Trusted publishing to PyPI via GitHub Actions OIDC on a `v*` tag (#47). No
+  API token is stored in the repository.
+
 ## [0.6.0b0] - 2026-07-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -64,28 +64,45 @@ A few things are Django-only today even though the underlying hook is framework-
 
 ## Installation
 
-**Not on PyPI yet** — install from source:
+```bash
+# uv (recommended)
+uv add "component-framework[fastapi]"     # or [django] / [litestar] / [flask]
+
+# or with pip
+pip install "component-framework[fastapi]"
+```
+
+Pick the extra for the web framework you're on. `pydantic>=2.0` is the only mandatory dependency; everything else — FastAPI, Django, Litestar, Flask, JinjaX, Channels — is optional, so you only pull in what you use.
+
+```bash
+pip install "component-framework[fastapi]"                       # single adapter
+pip install "component-framework[fastapi,django,litestar,flask]"  # several
+pip install "component-framework[all]"                            # every adapter, plus the websockets extra
+pip install "component-framework[fastapi,testing]"                # + the pytest helpers, see Testing below
+```
+
+The quotes matter in most shells — bare brackets are glob syntax in zsh and get eaten before pip sees them.
+
+Import an adapter whose extra you skipped and you get a deliberate error naming the fix, not a bare `ModuleNotFoundError`:
+
+```
+ImportError: 'jinjax' is not installed. Install the 'fastapi' extra:
+pip install 'component-framework[fastapi]'
+```
+
+> Extras were made optional in 0.3.0 — if you're upgrading from before that and assumed `fastapi`/`uvicorn`/`jinjax` came by default, see [CHANGELOG.md](CHANGELOG.md).
+
+### From a checkout
+
+For hacking on the framework itself:
 
 ```bash
 git clone https://github.com/fsecada01/component-framework.git
 cd component-framework
-
-# uv (recommended)
-uv pip install -e ".[fastapi]"   # or [django] / [litestar] / [flask] / [all]
-
-# or with pip
-pip install -e ".[fastapi]"
+uv pip install -e ".[dev]"
 ```
 
-`pydantic>=2.0` is the only mandatory dependency; everything else — FastAPI, Django, Litestar, Flask, JinjaX, Channels — is an optional extra so you only pull in what you use.
-
-```bash
-pip install -e ".[fastapi]"                        # single adapter
-pip install -e ".[fastapi,django,litestar,flask]"   # several
-pip install -e ".[all]"                             # everything, including dev-adjacent websockets extra
-```
-
-> Extras were made optional in 0.3.0 — if you're on an older checkout that assumed `fastapi`/`uvicorn`/`jinjax` installed by default, see [CHANGELOG.md](CHANGELOG.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ---
 
@@ -204,17 +221,27 @@ class ContactForm(FormComponent):
 ```
 
 ```python
-# Composition: slots + a composite parent
-from component_framework.core.composition import SlotComponent, CompositeComponent
+# Composition: a parent declares named slots, children fill them
+from component_framework.core import Component, registry
+from component_framework.core.composition import compose
 
 @registry.register("card")
-class Card(SlotComponent):
+class Card(Component):
     template_name = "card.html"
-    slots = ["header", "body", "footer"]
+    slots = ["header", "body", "footer"]   # omit to accept any slot name
 
-@registry.register("product_page")
-class ProductPage(CompositeComponent):
-    components = {"card": Card, "cart": CartComponent}
+@registry.register("cart_summary")
+class CartSummary(Component):
+    template_name = "cart_summary.html"
+
+# Assemble in one call. Each child's rendered HTML lands in the parent's
+# template context under `slots`, keyed by slot name.
+page = compose(
+    Card,
+    params={"title": "Your order"},
+    body=CartSummary(),
+)
+result = page.dispatch()
 ```
 
 ```python
@@ -233,15 +260,21 @@ class OrderEditor(DjangoModelComponent):
 ```
 
 ```python
-# Testing a component without an HTTP server
+# Testing a component without an HTTP server.
+# Needs the `testing` extra: pip install "component-framework[testing]"
 from component_framework.testing import ComponentTestCase
 
 class TestCounter(ComponentTestCase):
+    component_class = Counter          # a MockRenderer is installed per test
+
+    def test_initial_state(self):
+        result = self.mount()
+        assert result["state"]["count"] == 0
+
     def test_increment(self):
-        component = self.mount_component("counter")
-        self.assert_state(component, count=0)
-        self.dispatch_event(component, "increment", amount=5)
-        self.assert_state(component, count=5)
+        self.mount()
+        self.dispatch("increment", {"amount": 5})
+        self.assert_state(count=5)
 ```
 
 More worked examples: [`docs/examples/ecommerce.md`](docs/examples/ecommerce.md) (real-time cart), [`docs/examples/wizard.md`](docs/examples/wizard.md) (multi-step FastAPI wizard), and the runnable apps under [`examples/`](examples/).

--- a/docs/CBV_GUIDE.md
+++ b/docs/CBV_GUIDE.md
@@ -316,7 +316,8 @@ class CachedView(CacheMixin, ComponentView):
 Add rate limiting (requires django-ratelimit).
 
 ```python
-from component_framework.adapters.django_views import RateLimitMixin, ComponentView
+from component_framework.adapters.django_ratelimit import RateLimitMixin
+from component_framework.adapters.django_views import ComponentView
 
 class RateLimitedView(RateLimitMixin, ComponentView):
     rate_limit_key = "component"

--- a/docs/LOCKED_FIELDS.md
+++ b/docs/LOCKED_FIELDS.md
@@ -19,7 +19,7 @@ client must never influence, in either mode.
 ```python
 from typing import ClassVar
 
-from component_framework import Component, registry
+from component_framework.core import Component, registry
 
 
 @registry.register("account_panel")

--- a/docs/examples/ecommerce.md
+++ b/docs/examples/ecommerce.md
@@ -79,7 +79,7 @@ pip install component-framework django django-channels
 ```python
 # settings.py
 INSTALLED_APPS = [
-    ...
+    ...,
     "channels",
     "component_framework",
 ]
@@ -611,7 +611,7 @@ serialisation/deserialisation.
 class CartComponent(Component):
 
     def on_add_item(self, product_id: int, size: str):
-        # ... 10 lines of plain Python (see above) ...
+        ...  # 10 lines of plain Python, see above
 
     def get_optimistic_patch(self, event: str, payload: dict) -> dict | None:
         if event == "add_item":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "component-framework"
-version = "0.6.0b0"
+version = "0.6.0"
 description = "Framework-agnostic server components with LiveView-style interactivity"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,21 @@ keywords = ["components", "server-components", "liveview", "htmx", "fastapi", "d
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
+    # PyPI's sidebar reads the license from this classifier, not from the
+    # `license` field.
+    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Framework :: Django",
+    "Framework :: FastAPI",
+    "Framework :: Flask",
+    "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
+    "Typing :: Typed",
 ]
 
 dependencies = [
@@ -46,6 +56,13 @@ flask = [
 ]
 websockets = [
     "websockets>=12.0",
+]
+# `component_framework.testing` imports pytest at module scope — it ships
+# pytest fixtures and a pytest-style base class. Without this extra a
+# consumer following the README's testing sample hit ModuleNotFoundError,
+# because pytest was only reachable through `dev-base` (#49).
+testing = [
+    "pytest>=7.4.0",
 ]
 dev-base = [
     "pytest>=7.4.0",

--- a/tests/test_docs_samples.py
+++ b/tests/test_docs_samples.py
@@ -1,0 +1,201 @@
+"""The documentation's code samples are checked against the real package (#49).
+
+Prose rots silently, and nothing here read the docs until this file existed.
+Two dead samples were sitting in the tree when it was written, both of which
+read perfectly:
+
+* ``from component_framework.core.composition import SlotComponent,
+  CompositeComponent`` — neither name exists. ``composition`` exports
+  ``compose`` and ``SlotRenderer``. The surrounding README example was
+  invented wholesale, down to a ``components = {...}`` attribute nothing
+  reads.
+* ``from component_framework import Component, registry`` — the top-level
+  ``__init__`` exports only ``CorruptStateError`` and ``StateSigner``. Both
+  names live in ``component_framework.core``.
+
+Neither is the kind of thing review catches, because both are what you would
+guess the API looks like. So the docs are parsed and their claims executed:
+every ``python`` block must parse, and every name imported from
+``component_framework`` must actually exist on the module it is imported
+from.
+
+Ported from cf-ui's ``tests/unit/test_docs_samples.py``, which exists for the
+same reason — ``ComponentCatalog`` and ``<CfCard>`` sat in that README for
+two releases.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import re
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+
+#: Fenced blocks, including indented ones inside list items or admonitions —
+#: the closing fence must match the opening fence's indent.
+FENCE = re.compile(r"^([ \t]*)```(\w+)?[^\n]*\n(.*?)^\1```", re.M | re.S)
+
+#: Docs that are published to a reader. ``docs/reports/`` is deliberately
+#: excluded: those are point-in-time build records, not instructions, and
+#: pinning their samples would freeze history rather than protect a reader.
+DOC_GLOBS = ["README.md", "CONTRIBUTING.md", "docs/*.md", "docs/examples/*.md"]
+
+
+def _doc_files() -> list[Path]:
+    seen: dict[Path, None] = {}
+    for pattern in DOC_GLOBS:
+        for path in sorted(REPO_ROOT.glob(pattern)):
+            seen[path] = None
+    return list(seen)
+
+
+def _rel(path: Path) -> str:
+    return str(path.relative_to(REPO_ROOT)).replace("\\", "/")
+
+
+DOC_FILES = _doc_files()
+
+
+def test_the_doc_set_the_guard_walks_is_not_empty():
+    """A guard over an empty glob passes. Pin what it is supposed to cover."""
+    names = {_rel(p) for p in DOC_FILES}
+    assert "README.md" in names
+    for expected in ("docs/LOCKED_FIELDS.md", "docs/STATE_SIGNING.md", "docs/CBV_GUIDE.md"):
+        assert expected in names, f"{expected} missing from the guarded doc set"
+
+
+def _python_blocks() -> list[tuple[Path, str]]:
+    out = []
+    for path in DOC_FILES:
+        text = path.read_text(encoding="utf-8")
+        for match in FENCE.finditer(text):
+            if (match.group(2) or "") in ("python", "py"):
+                out.append((path, textwrap.dedent(match.group(3))))
+    return out
+
+
+PYTHON_BLOCKS = _python_blocks()
+
+
+@pytest.mark.parametrize(
+    ("path", "source"),
+    PYTHON_BLOCKS,
+    ids=[f"{_rel(p)}:{i}" for i, (p, _) in enumerate(PYTHON_BLOCKS)],
+)
+def test_every_python_sample_parses(path: Path, source: str):
+    try:
+        ast.parse(source)
+    except SyntaxError as exc:
+        pytest.fail(f"{_rel(path)}: sample does not parse: {exc}\n\n{source}")
+
+
+def _imported_names() -> list[tuple[Path, str, str]]:
+    """(file, module, name) for every documented ``from component_framework…``.
+
+    Blocks that do not parse are skipped here rather than raising at
+    collection time — ``test_every_python_sample_parses`` is what reports
+    those, and a collection error would hide every other finding in this
+    module behind it.
+    """
+    out = []
+    for path, source in PYTHON_BLOCKS:
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.ImportFrom) and node.module and node.level == 0):
+                continue
+            if node.module != "component_framework" and not node.module.startswith(
+                "component_framework."
+            ):
+                continue
+            for alias in node.names:
+                out.append((path, node.module, alias.name))
+    return out
+
+
+IMPORTED_NAMES = _imported_names()
+
+
+@pytest.mark.parametrize(
+    ("path", "module", "name"),
+    IMPORTED_NAMES,
+    ids=[f"{_rel(p)}:{m}.{n}" for p, m, n in IMPORTED_NAMES],
+)
+def test_every_documented_import_exists(path: Path, module: str, name: str):
+    """``SlotComponent`` is the bug this test exists for.
+
+    An adapter whose extra is not installed raises a deliberate, well-worded
+    ``ImportError`` ("Install the 'django' extra: …"). That is the package
+    working as designed, not a doc defect, so it is skipped —
+    ``test_the_import_check_is_not_all_skips`` keeps that from hollowing the
+    check out.
+    """
+    try:
+        mod = importlib.import_module(module)
+    except ImportError as exc:
+        pytest.skip(f"optional dependency missing for {module}: {exc}")
+
+    assert hasattr(mod, name), (
+        f"{_rel(path)} documents `from {module} import {name}`, but {module} "
+        f"exposes no such name. Available: "
+        f"{', '.join(sorted(n for n in dir(mod) if not n.startswith('_'))[:12])}…"
+    )
+
+
+def test_the_import_check_is_not_all_skips():
+    """At least the core imports must have been really checked.
+
+    Every one of these resolves with no optional extra installed, so a skip
+    here means the sample stopped being documented, not that the environment
+    is thin.
+    """
+    checked = {(m, n) for _, m, n in IMPORTED_NAMES}
+    for required in [
+        ("component_framework.core", "Component"),
+        ("component_framework.core", "registry"),
+    ]:
+        assert required in checked, (
+            f"no doc sample imports {required[1]} from {required[0]} any more — "
+            "either the docs regressed or this list is stale."
+        )
+
+
+def test_the_fence_regex_finds_the_blocks_it_claims_to():
+    """Pin the extractor: a regex that stops matching reports clean forever."""
+    doc = (
+        "text\n\n```python\nx = 1\n```\n\n"
+        "- item:\n\n    ```python\n    y = 2\n    ```\n\n"  # indented fence
+        "```bash\nls\n```\n"
+    )
+    found = [(m.group(2), textwrap.dedent(m.group(3))) for m in FENCE.finditer(doc)]
+    assert found == [("python", "x = 1\n"), ("python", "y = 2\n"), ("bash", "ls\n")]
+    assert len(PYTHON_BLOCKS) >= 20, f"only {len(PYTHON_BLOCKS)} python samples found"
+
+
+# ── The README's install instructions must describe the published package ──
+
+
+def test_the_readme_documents_installing_from_pypi():
+    """The README *is* the PyPI landing page.
+
+    Before #49 every install line was `pip install -e ".[extra]"` — an
+    editable install from a checkout — and the section opened with "Not on
+    PyPI yet". A visitor arriving from PyPI found no instruction that applied
+    to them.
+    """
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert "Not on PyPI" not in readme, (
+        "the README still claims the package is not on PyPI; it is published now"
+    )
+    assert re.search(r"(?:pip|uv pip) install ['\"]?component-framework\[", readme), (
+        "the README never shows `pip install component-framework[extra]` — the one "
+        "line a reader arriving from the PyPI page needs."
+    )


### PR DESCRIPTION
Closes #47. Closes #49.

Promotes `0.6.0b0` to a final release, adds the workflow that publishes it, and fixes the things that made the package installable but not yet fit to hand to someone.

## Why stable, and why this repo first

cf-ui's wheel declares `Requires-Dist: component-framework>=0.4` — the `[tool.uv.sources]` git pin does **not** travel into wheel metadata — so `pip install cf-ui` cannot resolve until this package is on PyPI. Ordering is forced.

Publishing the beta would have worked only by accident. A specifier with no pre-release marker resolves to a pre-release *only* when no final release exists, so `>=0.4` → `0.6.0b0` today, but that resolution would flip silently the first time any stable version appeared — and a stable cf-ui 0.2.0 would have shipped depending on a beta.

## Publishing (#47)

Trusted publishing (OIDC), not a stored API token. The `publish` job requests `id-token: write`, mints a short-lived token, and PyPI exchanges it for upload rights. Gated behind a `pypi` GitHub environment, so you can add a required-reviewer rule if you want a human ack on every release.

Three guards run before anything is uploaded, because a bad upload can be yanked but **never replaced**:

- `twine check` on both the wheel and the sdist
- the git tag must match `pyproject.toml`'s version, so a `v0.6.0` tag cannot publish a wheel built from a different number
- the wheel must contain the client assets and `py.typed`. Those ship inside the package with no explicit hatchling include, so a packaging regression produces a wheel that installs and imports cleanly and then serves **no interactivity** — nothing in the test suite would notice, because every test runs against the source tree. Verified it can fail: a wheel rebuilt without `py.typed` and `component-client.js` exits 1 naming both.

## What the audit found (#49)

I built the wheel, installed it into a clean venv, and checked every documented import against the **installed package** rather than the source tree. Six samples did not work, and two pieces of metadata were missing.

### The README described an install nobody could perform

Every instruction was `pip install -e ".[extra]"` — an editable install from a checkout — and the section opened with **"Not on PyPI yet"**, which stops being true the moment this uploads. The README *is* the PyPI landing page, so the one line a visitor arriving there needs was the one that was missing.

It now leads with `pip install "component-framework[fastapi]"`, notes the quoting (bare brackets are glob syntax in zsh), shows the missing-extra `ImportError` a reader will actually meet, and demotes the editable install to a contributor note.

### Six samples that do not run

| Where | Documented | Reality |
|---|---|---|
| README (composition) | `SlotComponent`, `CompositeComponent` from `core.composition` | Neither exists. The whole example was invented, down to a `components = {...}` attribute nothing reads. Real API: a `Component` with a `slots` ClassVar, assembled with `compose()` |
| README (testing) | `mount_component`, `dispatch_event`, `assert_state(component, …)` | None exist; it also omitted the required `component_class` |
| `docs/LOCKED_FIELDS.md` | `from component_framework import Component, registry` | Top-level exports only `CorruptStateError`, `StateSigner` |
| `docs/CBV_GUIDE.md` | `RateLimitMixin` from `adapters.django_views` | Lives in `adapters.django_ratelimit` — as the README said all along |
| `docs/examples/ecommerce.md` ×2 | — | Do not parse: a bare `...` in a list literal, and a method whose body was only a comment |

### Packaging

- **`py.typed`.** The codebase is type-checked in CI and ships `component-client.d.ts` so *TypeScript* consumers get types for the client JS — but with no PEP 561 marker, every *Python* consumer running mypy or pyright saw the whole package as untyped. The types existed; they just were not advertised.
- **A `testing` extra** declaring pytest. `component_framework.testing` imports pytest at module scope — it ships fixtures and a pytest-style base class — but pytest was only reachable through `dev-base`, so following the README's testing sample after `pip install component-framework[fastapi]` raised `ModuleNotFoundError`.
- **Classifiers**: 7 → 15. Adds the license (which is what PyPI's sidebar reads), the frameworks the adapters target, and `Typing :: Typed`.

## Why all six shipped

**Nothing here read the documentation.** `tests/test_docs_samples.py` now parses every fenced `python` block in the README, CONTRIBUTING and `docs/`, and resolves every `from component_framework… import …` against the real package.

Run against the previous text it produces **8 failures** — all six samples, plus the "Not on PyPI" claim. Three of those eight were ones my own manual audit had missed (`RateLimitMixin` and both ecommerce parse errors), which is the argument for the guard rather than a careful read.

Ported from cf-ui's `test_docs_samples.py`, which exists for exactly the same reason: `ComponentCatalog` and `<CfCard>` sat in that README for two releases.

## Verified

- 659 tests pass; ruff clean; CI green on all four Python versions
- A clean install now resolves **34** documented imports where it resolved 15
- Wheel: `License-File: LICENSE`, 15 classifiers, `py.typed` present, `twine check` PASSED on wheel and sdist
- Name `component-framework` is free on PyPI

## Manual step before this can publish

Trusted publishing needs a **pending publisher** registered *before* the first upload — the workflow will fail without it. On pypi.org → Your projects → Publishing → add a pending publisher:

| Field | Value |
|---|---|
| PyPI Project Name | `component-framework` |
| Owner | `fsecada01` |
| Repository name | `component-framework` |
| Workflow name | `release.yml` |
| Environment name | `pypi` |

Then merge this and push a tag: `git tag v0.6.0 && git push origin v0.6.0`.

## Not in this PR

- The pre-existing dirty working tree (`justfile`, `specs/`, `.claude/`) is untouched — none of it is staged here.
- The README's 22 relative links resolve on GitHub and 404 on PyPI. Real, but the `Documentation` project URL points at the live docs site, so a PyPI visitor is one click from working links.
- **Heads up, unrelated:** the `ty` prek hook exits 1 locally on `master` as well as on this branch, while CI's `lint` job passes. CI installs the `ty==0.0.25` pin from `.[dev]`; a locally-installed `ty` on PATH (0.0.64 here) shadows it and fails on the intentionally warn-level diagnostics. Worth a separate ticket — it means local `prek` is not the CI parity check the config comment claims it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhqNRBg83czKfr8L6FF5xf
